### PR TITLE
Add support for CSS Grid Module Levels 2 and 3

### DIFF
--- a/includes/StylePropertySanitizerExtender.php
+++ b/includes/StylePropertySanitizerExtender.php
@@ -200,16 +200,16 @@ class StylePropertySanitizerExtender extends StylePropertySanitizer {
 		$subgrid = new Juxtaposition( [ $lineNamesO, new KeywordMatcher( 'subgrid' ), $lineNamesO ] );
 
 		$props['grid-template-columns'] = new Alternative( [
-		new KeywordMatcher( [ 'none', 'masonry' ] ),
-		$trackList,
-		$autoTrackList,
-		$subgrid,
+			new KeywordMatcher( [ 'none', 'masonry' ] ),
+			$trackList,
+			$autoTrackList,
+			$subgrid,
 		] );
 		$props['grid-template-rows'] = $props['grid-template-columns'];
 
 		$props['masonry-auto-flow'] = new Juxtaposition( [
-		new KeywordMatcher( [ 'pack', 'next' ] ),
-		Quantifier::optional( new KeywordMatcher( 'definite-first' ) )
+			new KeywordMatcher( [ 'pack', 'next' ] ),
+			Quantifier::optional( new KeywordMatcher( 'definite-first' ) )
 		] );
 
 		$this->cache[__METHOD__] = $props;

--- a/includes/StylePropertySanitizerExtender.php
+++ b/includes/StylePropertySanitizerExtender.php
@@ -197,10 +197,20 @@ class StylePropertySanitizerExtender extends StylePropertySanitizer {
 			$lineNamesO,
 		] );
 
+		$subgrid = new Juxtaposition( [ $lineNamesO, new KeywordMatcher( 'subgrid' ), $lineNamesO ] );
+
 		$props['grid-template-columns'] = new Alternative( [
-			new KeywordMatcher( 'none' ), $trackList, $autoTrackList
+		new KeywordMatcher( [ 'none', 'masonry' ] ),
+		$trackList,
+		$autoTrackList,
+		$subgrid,
 		] );
 		$props['grid-template-rows'] = $props['grid-template-columns'];
+
+		$props['masonry-auto-flow'] = new Juxtaposition( [
+		new KeywordMatcher( [ 'pack', 'next' ] ),
+		Quantifier::optional( new KeywordMatcher( 'definite-first' ) )
+		] );
 
 		$this->cache[__METHOD__] = $props;
 		return $props;

--- a/tests.css
+++ b/tests.css
@@ -18,10 +18,36 @@
 }
 
 .ts-css-custom-properties-value-grid {
-	grid-template-columns: repeat(2, minmax(0, 1fr)) var(--right-rail-size);
-	grid-template-columns: 1fr var(--right-rail-size);
-	grid-template-columns: minmax(0, 1fr) var(--right-rail-size);
-	grid-template-columns: repeat(var(--column-foo), minmax(0, 1fr));
+        grid-template-columns: repeat(2, minmax(0, 1fr)) var(--right-rail-size);
+        grid-template-columns: 1fr var(--right-rail-size);
+        grid-template-columns: minmax(0, 1fr) var(--right-rail-size);
+        grid-template-columns: repeat(var(--column-foo), minmax(0, 1fr));
+}
+
+/**
+ * CSS Grid Module Level 2
+ */
+.ts-css-grid-2 {
+        grid-template-columns: subgrid;
+        grid-template-columns: [col-start] subgrid;
+        grid-template-columns: subgrid [col-end];
+        grid-template-columns: [col-start] subgrid [col-end];
+        grid-template-rows: subgrid;
+        grid-template-rows: [row-start] subgrid;
+        grid-template-rows: subgrid [row-end];
+        grid-template-rows: [row-start] subgrid [row-end];
+}
+
+/**
+ * CSS Grid Module Level 3
+ */
+.ts-css-grid-3 {
+        grid-template-columns: masonry;
+        grid-template-rows: masonry;
+        masonry-auto-flow: pack;
+	masonry-auto-flow: next;
+	masonry-auto-flow: pack definite-first;
+	masonry-auto-flow: next definite-first;
 }
 
 /**

--- a/tests.css
+++ b/tests.css
@@ -18,33 +18,33 @@
 }
 
 .ts-css-custom-properties-value-grid {
-        grid-template-columns: repeat(2, minmax(0, 1fr)) var(--right-rail-size);
-        grid-template-columns: 1fr var(--right-rail-size);
-        grid-template-columns: minmax(0, 1fr) var(--right-rail-size);
-        grid-template-columns: repeat(var(--column-foo), minmax(0, 1fr));
+	grid-template-columns: repeat(2, minmax(0, 1fr)) var(--right-rail-size);
+	grid-template-columns: 1fr var(--right-rail-size);
+	grid-template-columns: minmax(0, 1fr) var(--right-rail-size);
+	grid-template-columns: repeat(var(--column-foo), minmax(0, 1fr));
 }
 
 /**
  * CSS Grid Module Level 2
  */
 .ts-css-grid-2 {
-        grid-template-columns: subgrid;
-        grid-template-columns: [col-start] subgrid;
-        grid-template-columns: subgrid [col-end];
-        grid-template-columns: [col-start] subgrid [col-end];
-        grid-template-rows: subgrid;
-        grid-template-rows: [row-start] subgrid;
-        grid-template-rows: subgrid [row-end];
-        grid-template-rows: [row-start] subgrid [row-end];
+	grid-template-columns: subgrid;
+	grid-template-columns: [col-start] subgrid;
+	grid-template-columns: subgrid [col-end];
+	grid-template-columns: [col-start] subgrid [col-end];
+	grid-template-rows: subgrid;
+	grid-template-rows: [row-start] subgrid;
+	grid-template-rows: subgrid [row-end];
+	grid-template-rows: [row-start] subgrid [row-end];
 }
 
 /**
  * CSS Grid Module Level 3
  */
 .ts-css-grid-3 {
-        grid-template-columns: masonry;
-        grid-template-rows: masonry;
-        masonry-auto-flow: pack;
+	grid-template-columns: masonry;
+	grid-template-rows: masonry;
+	masonry-auto-flow: pack;
 	masonry-auto-flow: next;
 	masonry-auto-flow: pack definite-first;
 	masonry-auto-flow: next definite-first;


### PR DESCRIPTION
## Summary
- allow `subgrid` values for `grid-template-columns` and `grid-template-rows`
- allow `masonry` values for `grid-template-columns` and `grid-template-rows`
- add `masonry-auto-flow` property
- cover CSS Grid Levels 2 and 3 in tests

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68abc2a8af208333b476ad5603a9ae8e